### PR TITLE
Incremented sleep variable in the work_handler

### DIFF
--- a/Chapter03/shared-workqueue.c
+++ b/Chapter03/shared-workqueue.c
@@ -22,6 +22,7 @@ static void work_handler(struct work_struct *work)
                                  struct work_data, my_work); 
     pr_info("Work queue module handler: %s, data is %d\n", __FUNCTION__, my_data->the_data);
     msleep(3000);
+    sleep++;
     wake_up_interruptible(&my_data->my_wq);
     kfree(my_data);
 }


### PR DESCRIPTION
The `static int sleep` is set as 0 and then it's used in `wait_event_interruptible` function as a condition `sleep != 0`. This check will never be true as the sleep is always 0. Therefore, it needs to be !=0, so needs to be incremented in `work_handler`.