### PR TITLE
Cancel sleep flag after slept.

### DIFF
--- a/Chapter03/shared-workqueue.c
+++ b/Chapter03/shared-workqueue.c
@@ -22,6 +22,7 @@ static void work_handler(struct work_struct *work)
                                  struct work_data, my_work); 
     pr_info("Work queue module handler: %s, data is %d\n", __FUNCTION__, my_data->the_data);
     msleep(3000);
+    sleep = 1;
     wake_up_interruptible(&my_data->my_wq);
     kfree(my_data);
 }


### PR DESCRIPTION
Set sleep to 1, after `msleep(3000);`, or `insmod shared-workqueue.ko` will be hanging, since work never wake up.